### PR TITLE
Add per-app volume hotkeys with custom step size and extended key mappings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(QML_FILES
     qml/SettingsPane/DebugPane.qml
     qml/SettingsPane/CommAppsPane.qml
     qml/SettingsPane/ShortcutsPane.qml
+    qml/SettingsPane/AppHotkeysPane.qml
     qml/SettingsPane/HeadsetControlPane.qml
     qml/SettingsPane/ConsolePane.qml
     qml/SettingsPane/DeviceRenamingPane.qml

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Hinzufügen</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Entfernen</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -974,6 +1029,10 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     <message>
         <source>Debug</source>
         <translation>Debug</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -971,6 +1026,10 @@ You can enable it in the General tab.</source>
     </message>
     <message>
         <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr_FR">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Ajouter</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Retirer</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Top</source>
@@ -978,6 +1033,10 @@ Vous pouvez l&apos;activer dans l&apos;onglet Général.</translation>
     <message>
         <source>Debug</source>
         <translation>Déboguer</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="it_IT">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Aggiungi</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Rimuovi</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annulla</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -974,6 +1029,10 @@ Puoi abilitarlo nella scheda Generale.</translation>
     <message>
         <source>Debug</source>
         <translation>Debug</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ja_JP">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">追加</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">削除</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -973,6 +1028,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Debug</source>
         <translation>デバッグ</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko_KR">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">추가</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">제거</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -974,6 +1029,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Components</source>
         <translation>구성 요소</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pl_PL" sourcelanguage="en_US">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Dodaj</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Usuń</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -974,6 +1029,10 @@ Można ją włączyć w zakładce Ogólne.</translation>
     <message>
         <source>Debug</source>
         <translation>Debugowanie</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Добавить</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Удалить</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -971,6 +1026,10 @@ You can enable it in the General tab.</source>
     </message>
     <message>
         <source>Components</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -2,6 +2,61 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>AppHotkeysPane</name>
+    <message>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">移除</translation>
+    </message>
+    <message>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click to set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume Step Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
         <source>Appearance &amp; Position</source>
@@ -972,6 +1027,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Components</source>
         <translation>组件</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/include/audiobridge.h
+++ b/include/audiobridge.h
@@ -41,6 +41,7 @@ class AudioBridge : public QObject
 public:
     explicit AudioBridge(QObject *parent = nullptr);
     ~AudioBridge();
+    static AudioBridge* instance();
     static AudioBridge* create(QQmlEngine *qmlEngine, QJSEngine *jsEngine);
 
     // Properties
@@ -121,6 +122,8 @@ public:
     Q_INVOKABLE bool isApplicationMutedInBackground(const QString& executableName) const;
     Q_INVOKABLE void setApplicationMutedInBackground(const QString& executableName, bool muted);
 
+    Q_INVOKABLE int getExecutableVolume(const QString& executableName) const;
+
 signals:
     void outputVolumeChanged();
     void inputVolumeChanged();
@@ -143,6 +146,7 @@ signals:
     void inputDeviceCountChanged();
 
 private slots:
+    void onAppVolumeHotkeyPressed(const QString &executableName, bool volumeUp, int volumeStepSize);
     void onOutputVolumeChanged(int volume);
     void onInputVolumeChanged(int volume);
     void onOutputMuteChanged(bool muted);
@@ -261,6 +265,7 @@ private:
     void saveDeviceIconsToFile();
     QString getDeviceIconsFilePath() const;
 
+    static AudioBridge* m_instance;
     WindowFocusManager* m_windowFocusManager;
     QMap<QString, bool> m_originalMuteStates;
 

--- a/include/keyboardshortcutmanager.h
+++ b/include/keyboardshortcutmanager.h
@@ -3,7 +3,20 @@
 #include <QQmlEngine>
 #include <QAbstractNativeEventFilter>
 #include <QMap>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <Windows.h>
+
+struct AppVolumeHotkey {
+    QString executableName;
+    int volumeUpKey = 0;
+    int volumeUpModifiers = 0;
+    int volumeDownKey = 0;
+    int volumeDownModifiers = 0;
+    int volumeStepSize = 0;
+    int volumeUpHotkeyId = 0;
+    int volumeDownHotkeyId = 0;
+};
 
 class KeyboardShortcutManager : public QObject, public QAbstractNativeEventFilter
 {
@@ -11,6 +24,7 @@ class KeyboardShortcutManager : public QObject, public QAbstractNativeEventFilte
     QML_ELEMENT
     QML_SINGLETON
     Q_PROPERTY(bool globalShortcutsSuspended READ globalShortcutsSuspended WRITE setGlobalShortcutsSuspended NOTIFY globalShortcutsSuspendedChanged)
+    Q_PROPERTY(QJsonArray appVolumeHotkeys READ appVolumeHotkeysJson NOTIFY appVolumeHotkeysChanged)
 
 public:
     static KeyboardShortcutManager* instance();
@@ -22,6 +36,11 @@ public:
 
     Q_INVOKABLE void manageGlobalShortcuts(bool enabled);
 
+    // Per-app volume hotkeys
+    Q_INVOKABLE bool addAppVolumeHotkey(const QString &executableName, int volUpKey, int volUpMods, int volDownKey, int volDownMods, int volumeStepSize = 0);
+    Q_INVOKABLE void removeAppVolumeHotkey(const QString &executableName);
+    QJsonArray appVolumeHotkeysJson() const;
+
     // Native event filter to handle WM_HOTKEY messages
     bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result) override;
 
@@ -32,6 +51,8 @@ signals:
     void chatMixNotificationRequested(QString message);
     void chatMixToggleRequested();
     void micMuteToggleRequested();
+    void appVolumeHotkeyPressed(const QString &executableName, bool volumeUp, int volumeStepSize);
+    void appVolumeHotkeysChanged();
 
 private:
     explicit KeyboardShortcutManager(QObject *parent = nullptr);
@@ -43,6 +64,8 @@ private:
         HOTKEY_MIC_MUTE = 3
     };
 
+    static const int APP_HOTKEY_BASE_ID = 100;
+
     int qtKeyToVirtualKey(int qtKey);
     UINT convertQtModifiers(int qtMods);
     bool m_globalShortcutsSuspended = false;
@@ -50,8 +73,18 @@ private:
     HWND m_hwnd = nullptr;
     QMap<int, bool> m_registeredHotkeys;
 
+    // Per-app volume hotkeys
+    QList<AppVolumeHotkey> m_appVolumeHotkeys;
+    int m_nextAppHotkeyId = APP_HOTKEY_BASE_ID;
+
     void registerHotkeys();
     void unregisterHotkeys();
     void updateHotkey(HotkeyId id, int qtKey, int qtMods);
     void toggleChatMixFromShortcut(bool enabled);
+
+    void registerAppVolumeHotkeys();
+    void unregisterAppVolumeHotkeys();
+    void loadAppVolumeHotkeys();
+    void saveAppVolumeHotkeys();
+    QString getAppVolumeHotkeysFilePath() const;
 };

--- a/qml/SettingsPane/AppHotkeysPane.qml
+++ b/qml/SettingsPane/AppHotkeysPane.qml
@@ -1,0 +1,297 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls.FluentWinUI3
+import Odizinne.QontrolPanel
+
+ColumnLayout {
+    id: root
+    spacing: 3
+
+    Label {
+        text: qsTr("App Volume Hotkeys")
+        font.pixelSize: 22
+        font.bold: true
+        Layout.bottomMargin: 15
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        CustomScrollView {
+            anchors.fill: parent
+
+            Column {
+                width: parent.width
+                spacing: 3
+
+                Card {
+                    width: parent.width
+                    title: qsTr("Per-application volume shortcuts")
+                    description: qsTr("Assign global hotkeys to control volume of specific applications")
+                    additionalControl: Button {
+                        text: qsTr("Add")
+                        enabled: UserSettings.globalShortcutsEnabled
+                        onClicked: addHotkeyDialog.open()
+                    }
+                }
+
+                Repeater {
+                    id: hotkeyRepeater
+                    model: KeyboardShortcutManager.appVolumeHotkeys
+
+                    Card {
+                        id: hotkeyCard
+                        required property var modelData
+                        required property int index
+                        width: parent.width
+                        title: hotkeyCard.modelData.executableName
+                        description: "▲ " + Context.getShortcutText(hotkeyCard.modelData.volumeUpModifiers, hotkeyCard.modelData.volumeUpKey) +
+                                     "  ▼ " + Context.getShortcutText(hotkeyCard.modelData.volumeDownModifiers, hotkeyCard.modelData.volumeDownKey) +
+                                     (hotkeyCard.modelData.volumeStepSize > 0 ? "  (" + qsTr("Step") + ": " + hotkeyCard.modelData.volumeStepSize + ")" : "")
+
+                        additionalControl: Button {
+                            text: qsTr("Remove")
+                            onClicked: {
+                                KeyboardShortcutManager.removeAppVolumeHotkey(hotkeyCard.modelData.executableName)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Dialog {
+            id: addHotkeyDialog
+            title: qsTr("Add App Volume Hotkey")
+            modal: true
+            width: 450
+            anchors.centerIn: parent
+
+            property int volUpKey: Qt.Key_unknown
+            property int volUpMods: 0
+            property int volDownKey: Qt.Key_unknown
+            property int volDownMods: 0
+            property string selectedApp: ""
+            property bool capturingUp: false
+            property bool capturingDown: false
+            property int customStepSize: 2
+
+            onOpened: {
+                KeyboardShortcutManager.globalShortcutsSuspended = true
+                volUpKey = Qt.Key_unknown
+                volUpMods = 0
+                volDownKey = Qt.Key_unknown
+                volDownMods = 0
+                selectedApp = ""
+                capturingUp = false
+                capturingDown = false
+                customStepSize = 2
+                if (appComboBox.count > 0) {
+                    appComboBox.currentIndex = 0
+                }
+            }
+
+            onClosed: {
+                KeyboardShortcutManager.globalShortcutsSuspended = false
+            }
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 15
+
+                Label {
+                    text: qsTr("Application")
+                    font.bold: true
+                }
+
+                ComboBox {
+                    id: appComboBox
+                    Layout.fillWidth: true
+                    model: AudioBridge.groupedApplications
+                    textRole: "displayName"
+                    valueRole: "executableName"
+                    onCurrentIndexChanged: {
+                        if (currentIndex >= 0) {
+                            Qt.callLater(function() {
+                                addHotkeyDialog.selectedApp = appComboBox.currentValue
+                            })
+                        }
+                    }
+                }
+
+                Label {
+                    text: qsTr("Volume Up Shortcut")
+                    font.bold: true
+                    Layout.topMargin: 5
+                }
+
+                Rectangle {
+                    id: volUpRect
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 50
+                    color: Constants.footerColor
+                    radius: 5
+
+                    Rectangle {
+                        anchors.fill: parent
+                        border.width: 1
+                        border.color: addHotkeyDialog.capturingUp ? palette.accent : Constants.footerBorderColor
+                        opacity: addHotkeyDialog.capturingUp ? 1 : 0.15
+                        color: Constants.footerColor
+                        radius: 5
+
+                        Behavior on opacity {
+                            NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
+                        }
+                        Behavior on border.color {
+                            ColorAnimation { duration: 200; easing.type: Easing.OutQuad }
+                        }
+                    }
+
+                    Label {
+                        anchors.centerIn: parent
+                        text: addHotkeyDialog.volUpKey !== Qt.Key_unknown
+                              ? Context.getShortcutText(addHotkeyDialog.volUpMods, addHotkeyDialog.volUpKey)
+                              : qsTr("Click to set...")
+                        font.family: "Consolas, monospace"
+                        font.pixelSize: 14
+                        opacity: addHotkeyDialog.volUpKey !== Qt.Key_unknown ? 1 : 0.5
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            addHotkeyDialog.capturingUp = true
+                            addHotkeyDialog.capturingDown = false
+                            volUpRect.forceActiveFocus()
+                        }
+                    }
+
+                    Keys.onPressed: function(event) {
+                        if (!addHotkeyDialog.capturingUp) return
+                        let modifiers = 0
+                        if (event.modifiers & Qt.ControlModifier) modifiers |= Qt.ControlModifier
+                        if (event.modifiers & Qt.ShiftModifier) modifiers |= Qt.ShiftModifier
+                        if (event.modifiers & Qt.AltModifier) modifiers |= Qt.AltModifier
+
+                        addHotkeyDialog.volUpMods = modifiers
+                        addHotkeyDialog.volUpKey = event.key
+                        addHotkeyDialog.capturingUp = false
+                        event.accepted = true
+                    }
+                }
+
+                Label {
+                    text: qsTr("Volume Down Shortcut")
+                    font.bold: true
+                    Layout.topMargin: 5
+                }
+
+                Rectangle {
+                    id: volDownRect
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 50
+                    color: Constants.footerColor
+                    radius: 5
+
+                    Rectangle {
+                        anchors.fill: parent
+                        border.width: 1
+                        border.color: addHotkeyDialog.capturingDown ? palette.accent : Constants.footerBorderColor
+                        opacity: addHotkeyDialog.capturingDown ? 1 : 0.15
+                        color: Constants.footerColor
+                        radius: 5
+
+                        Behavior on opacity {
+                            NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
+                        }
+                        Behavior on border.color {
+                            ColorAnimation { duration: 200; easing.type: Easing.OutQuad }
+                        }
+                    }
+
+                    Label {
+                        anchors.centerIn: parent
+                        text: addHotkeyDialog.volDownKey !== Qt.Key_unknown
+                              ? Context.getShortcutText(addHotkeyDialog.volDownMods, addHotkeyDialog.volDownKey)
+                              : qsTr("Click to set...")
+                        font.family: "Consolas, monospace"
+                        font.pixelSize: 14
+                        opacity: addHotkeyDialog.volDownKey !== Qt.Key_unknown ? 1 : 0.5
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            addHotkeyDialog.capturingDown = true
+                            addHotkeyDialog.capturingUp = false
+                            volDownRect.forceActiveFocus()
+                        }
+                    }
+
+                    Keys.onPressed: function(event) {
+                        if (!addHotkeyDialog.capturingDown) return
+                        let modifiers = 0
+                        if (event.modifiers & Qt.ControlModifier) modifiers |= Qt.ControlModifier
+                        if (event.modifiers & Qt.ShiftModifier) modifiers |= Qt.ShiftModifier
+                        if (event.modifiers & Qt.AltModifier) modifiers |= Qt.AltModifier
+
+                        addHotkeyDialog.volDownMods = modifiers
+                        addHotkeyDialog.volDownKey = event.key
+                        addHotkeyDialog.capturingDown = false
+                        event.accepted = true
+                    }
+                }
+
+                Label {
+                    text: qsTr("Volume Step Size")
+                    font.bold: true
+                    Layout.topMargin: 5
+                }
+
+                SpinBox {
+                    id: stepSizeSpinBox
+                    Layout.fillWidth: true
+                    from: 1
+                    to: 100
+                    value: addHotkeyDialog.customStepSize
+                    onValueChanged: addHotkeyDialog.customStepSize = value
+                }
+
+                RowLayout {
+                    spacing: 15
+                    Layout.topMargin: 10
+
+                    Button {
+                        text: qsTr("Cancel")
+                        onClicked: addHotkeyDialog.close()
+                        Layout.fillWidth: true
+                    }
+
+                    Button {
+                        text: qsTr("Add")
+                        highlighted: true
+                        Layout.fillWidth: true
+                        enabled: addHotkeyDialog.selectedApp !== "" &&
+                                 addHotkeyDialog.volUpKey !== Qt.Key_unknown &&
+                                 addHotkeyDialog.volDownKey !== Qt.Key_unknown
+                        onClicked: {
+                            KeyboardShortcutManager.addAppVolumeHotkey(
+                                addHotkeyDialog.selectedApp,
+                                addHotkeyDialog.volUpKey,
+                                addHotkeyDialog.volUpMods,
+                                addHotkeyDialog.volDownKey,
+                                addHotkeyDialog.volDownMods,
+                                addHotkeyDialog.customStepSize
+                            )
+                            addHotkeyDialog.close()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -17,16 +17,16 @@ ApplicationWindow {
 
     function showUpdatePane() {
         show()
-        if (sidebarList.currentIndex !== 9) {
-            sidebarList.currentIndex = 9
+        if (sidebarList.currentIndex !== 10) {
+            sidebarList.currentIndex = 10
             stackView.push(debugPaneComponent)
         }
     }
 
     function showHeadsetcontrolPane() {
         show()
-        if (sidebarList.currentIndex !== 6) {
-            sidebarList.currentIndex = 6
+        if (sidebarList.currentIndex !== 7) {
+            sidebarList.currentIndex = 7
             stackView.push(headsetControlPaneComponent)
         }
     }
@@ -117,6 +117,10 @@ ApplicationWindow {
                             icon: "qrc:/icons/keyboard.svg"
                         },
                         {
+                            text: qsTr("App Hotkeys"),
+                            icon: "qrc:/icons/panel_volume_66.svg"
+                        },
+                        {
                             text: qsTr("HeadsetControl"),
                             icon: "qrc:/icons/headsetcontrol.svg"
                         },
@@ -144,7 +148,7 @@ ApplicationWindow {
 
                         function onLanguageIndexChanged() {
                             Qt.callLater(function() {
-                                sidebarList.currentIndex = 8
+                                sidebarList.currentIndex = 9
                             })
                         }
                     }
@@ -173,11 +177,12 @@ ApplicationWindow {
                                     case 3: stackView.push(mediaOverlayPaneComponent); break
                                     case 4: stackView.push(commAppsPaneComponent); break
                                     case 5: stackView.push(shortcutsPaneComponent); break
-                                    case 6: stackView.push(headsetControlPaneComponent); break
-                                    case 7: stackView.push(deviceRenamingPaneComponent); break
-                                    case 8: stackView.push(languagePaneComponent); break
-                                    case 9: stackView.push(debugPaneComponent); break
-                                    case 10: stackView.push(consolePaneComponent); break
+                                    case 6: stackView.push(appHotkeysPaneComponent); break
+                                    case 7: stackView.push(headsetControlPaneComponent); break
+                                    case 8: stackView.push(deviceRenamingPaneComponent); break
+                                    case 9: stackView.push(languagePaneComponent); break
+                                    case 10: stackView.push(debugPaneComponent); break
+                                    case 11: stackView.push(consolePaneComponent); break
                                 }
                             }
                         }
@@ -256,6 +261,11 @@ ApplicationWindow {
             Component {
                 id: shortcutsPaneComponent
                 ShortcutsPane {}
+            }
+
+            Component {
+                id: appHotkeysPaneComponent
+                AppHotkeysPane {}
             }
 
             Component {

--- a/qml/Singletons/Context.qml
+++ b/qml/Singletons/Context.qml
@@ -20,7 +20,19 @@ QtObject {
             [Qt.Key_Y]: "Y", [Qt.Key_Z]: "Z",
             [Qt.Key_F1]: "F1", [Qt.Key_F2]: "F2", [Qt.Key_F3]: "F3", [Qt.Key_F4]: "F4",
             [Qt.Key_F5]: "F5", [Qt.Key_F6]: "F6", [Qt.Key_F7]: "F7", [Qt.Key_F8]: "F8",
-            [Qt.Key_F9]: "F9", [Qt.Key_F10]: "F10", [Qt.Key_F11]: "F11", [Qt.Key_F12]: "F12"
+            [Qt.Key_F9]: "F9", [Qt.Key_F10]: "F10", [Qt.Key_F11]: "F11", [Qt.Key_F12]: "F12",
+            [Qt.Key_F13]: "F13", [Qt.Key_F14]: "F14", [Qt.Key_F15]: "F15", [Qt.Key_F16]: "F16",
+            [Qt.Key_F17]: "F17", [Qt.Key_F18]: "F18", [Qt.Key_F19]: "F19", [Qt.Key_F20]: "F20",
+            [Qt.Key_F21]: "F21", [Qt.Key_F22]: "F22", [Qt.Key_F23]: "F23", [Qt.Key_F24]: "F24",
+            [Qt.Key_0]: "0", [Qt.Key_1]: "1", [Qt.Key_2]: "2", [Qt.Key_3]: "3",
+            [Qt.Key_4]: "4", [Qt.Key_5]: "5", [Qt.Key_6]: "6", [Qt.Key_7]: "7",
+            [Qt.Key_8]: "8", [Qt.Key_9]: "9",
+            [Qt.Key_Up]: "Up", [Qt.Key_Down]: "Down", [Qt.Key_Left]: "Left", [Qt.Key_Right]: "Right",
+            [Qt.Key_Space]: "Space", [Qt.Key_Return]: "Enter", [Qt.Key_Enter]: "Enter",
+            [Qt.Key_Tab]: "Tab", [Qt.Key_Escape]: "Esc", [Qt.Key_Backspace]: "Backspace",
+            [Qt.Key_Delete]: "Delete", [Qt.Key_Insert]: "Insert",
+            [Qt.Key_Home]: "Home", [Qt.Key_End]: "End",
+            [Qt.Key_PageUp]: "Page Up", [Qt.Key_PageDown]: "Page Down"
         }
         return keyMap[key] || "Unknown"
     }

--- a/src/audiobridge.cpp
+++ b/src/audiobridge.cpp
@@ -2,9 +2,20 @@
 #include "audiomanager.h"
 #include "audiomodels.h"
 #include "usersettings.h"
+#include "keyboardshortcutmanager.h"
 #include "logmanager.h"
 #include <QDebug>
 #include <QQmlContext>
+
+AudioBridge* AudioBridge::m_instance = nullptr;
+
+AudioBridge* AudioBridge::instance()
+{
+    if (!m_instance) {
+        m_instance = new AudioBridge();
+    }
+    return m_instance;
+}
 
 AudioBridge::AudioBridge(QObject *parent)
     : QObject(parent)
@@ -50,6 +61,10 @@ AudioBridge::AudioBridge(QObject *parent)
             this, &AudioBridge::onApplicationFocusChanged);
     m_windowFocusManager->startMonitoring();
 
+    // Connect per-app volume hotkeys
+    connect(KeyboardShortcutManager::instance(), &KeyboardShortcutManager::appVolumeHotkeyPressed,
+            this, &AudioBridge::onAppVolumeHotkeyPressed);
+
     loadCommAppsFromFile();
     loadAppRenamesFromFile();
     loadExecutableRenamesFromFile();
@@ -89,7 +104,7 @@ AudioBridge* AudioBridge::create(QQmlEngine *qmlEngine, QJSEngine *jsEngine)
 {
     Q_UNUSED(qmlEngine)
     Q_UNUSED(jsEngine)
-    return new AudioBridge();
+    return instance();
 }
 
 // Grouped application methods
@@ -175,6 +190,31 @@ void AudioBridge::setExecutableVolume(const QString& executableName, int volume)
             }
         }
     }
+}
+
+int AudioBridge::getExecutableVolume(const QString& executableName) const
+{
+    int totalVolume = 0;
+    int count = 0;
+    for (int i = 0; i < m_applicationModel->rowCount(); ++i) {
+        QModelIndex index = m_applicationModel->index(i, 0);
+        QString appExeName = m_applicationModel->data(index, ApplicationModel::ExecutableNameRole).toString();
+        if (appExeName == executableName) {
+            totalVolume += m_applicationModel->data(index, ApplicationModel::VolumeRole).toInt();
+            count++;
+        }
+    }
+    return count > 0 ? totalVolume / count : -1;
+}
+
+void AudioBridge::onAppVolumeHotkeyPressed(const QString &executableName, bool volumeUp, int volumeStepSize)
+{
+    int currentVolume = getExecutableVolume(executableName);
+    if (currentVolume < 0) return;
+
+    int step = (volumeStepSize > 0) ? volumeStepSize : UserSettings::instance()->sliderWheelSensivity();
+    int newVolume = volumeUp ? qMin(100, currentVolume + step) : qMax(0, currentVolume - step);
+    setExecutableVolume(executableName, newVolume);
 }
 
 void AudioBridge::setExecutableMute(const QString& executableName, bool muted)

--- a/src/keyboardshortcutmanager.cpp
+++ b/src/keyboardshortcutmanager.cpp
@@ -2,6 +2,12 @@
 #include "usersettings.h"
 #include <QCoreApplication>
 #include <QWindow>
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
 
 KeyboardShortcutManager* KeyboardShortcutManager::m_instance = nullptr;
 
@@ -29,6 +35,9 @@ KeyboardShortcutManager::KeyboardShortcutManager(QObject *parent)
 
     // Install the native event filter
     QCoreApplication::instance()->installNativeEventFilter(this);
+
+    // Load per-app volume hotkeys from file
+    loadAppVolumeHotkeys();
 
     if (UserSettings::instance()->globalShortcutsEnabled()) {
         registerHotkeys();
@@ -108,6 +117,9 @@ void KeyboardShortcutManager::registerHotkeys()
     if (micMuteKey != 0 && RegisterHotKey(m_hwnd, HOTKEY_MIC_MUTE, micMuteMods, micMuteKey)) {
         m_registeredHotkeys[HOTKEY_MIC_MUTE] = true;
     }
+
+    // Register per-app volume hotkeys
+    registerAppVolumeHotkeys();
 }
 
 void KeyboardShortcutManager::unregisterHotkeys()
@@ -160,8 +172,10 @@ bool KeyboardShortcutManager::nativeEventFilter(const QByteArray &eventType, voi
                 return false;
             }
 
+            int hotkeyId = static_cast<int>(msg->wParam);
+
             // Handle the hotkey based on its ID
-            switch (msg->wParam) {
+            switch (hotkeyId) {
                 case HOTKEY_PANEL_TOGGLE:
                     emit panelToggleRequested();
                     return true;
@@ -171,6 +185,18 @@ bool KeyboardShortcutManager::nativeEventFilter(const QByteArray &eventType, voi
                 case HOTKEY_MIC_MUTE:
                     emit micMuteToggleRequested();
                     return true;
+            }
+
+            // Check per-app volume hotkeys
+            for (const auto &appHotkey : m_appVolumeHotkeys) {
+                if (hotkeyId == appHotkey.volumeUpHotkeyId) {
+                    emit appVolumeHotkeyPressed(appHotkey.executableName, true, appHotkey.volumeStepSize);
+                    return true;
+                }
+                if (hotkeyId == appHotkey.volumeDownHotkeyId) {
+                    emit appVolumeHotkeyPressed(appHotkey.executableName, false, appHotkey.volumeStepSize);
+                    return true;
+                }
             }
         }
     }
@@ -219,6 +245,205 @@ int KeyboardShortcutManager::qtKeyToVirtualKey(int qtKey)
     case Qt::Key_F10: return VK_F10;
     case Qt::Key_F11: return VK_F11;
     case Qt::Key_F12: return VK_F12;
+    case Qt::Key_F13: return VK_F13;
+    case Qt::Key_F14: return VK_F14;
+    case Qt::Key_F15: return VK_F15;
+    case Qt::Key_F16: return VK_F16;
+    case Qt::Key_F17: return VK_F17;
+    case Qt::Key_F18: return VK_F18;
+    case Qt::Key_F19: return VK_F19;
+    case Qt::Key_F20: return VK_F20;
+    case Qt::Key_F21: return VK_F21;
+    case Qt::Key_F22: return VK_F22;
+    case Qt::Key_F23: return VK_F23;
+    case Qt::Key_F24: return VK_F24;
+    case Qt::Key_0: return 0x30;
+    case Qt::Key_1: return 0x31;
+    case Qt::Key_2: return 0x32;
+    case Qt::Key_3: return 0x33;
+    case Qt::Key_4: return 0x34;
+    case Qt::Key_5: return 0x35;
+    case Qt::Key_6: return 0x36;
+    case Qt::Key_7: return 0x37;
+    case Qt::Key_8: return 0x38;
+    case Qt::Key_9: return 0x39;
+    case Qt::Key_Up: return VK_UP;
+    case Qt::Key_Down: return VK_DOWN;
+    case Qt::Key_Left: return VK_LEFT;
+    case Qt::Key_Right: return VK_RIGHT;
+    case Qt::Key_Space: return VK_SPACE;
+    case Qt::Key_Return: return VK_RETURN;
+    case Qt::Key_Enter: return VK_RETURN;
+    case Qt::Key_Tab: return VK_TAB;
+    case Qt::Key_Escape: return VK_ESCAPE;
+    case Qt::Key_Backspace: return VK_BACK;
+    case Qt::Key_Delete: return VK_DELETE;
+    case Qt::Key_Insert: return VK_INSERT;
+    case Qt::Key_Home: return VK_HOME;
+    case Qt::Key_End: return VK_END;
+    case Qt::Key_PageUp: return VK_PRIOR;
+    case Qt::Key_PageDown: return VK_NEXT;
     default: return 0;
     }
+}
+
+// Per-app volume hotkey methods
+
+QString KeyboardShortcutManager::getAppVolumeHotkeysFilePath() const
+{
+    QString appDataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir().mkpath(appDataPath);
+    return appDataPath + "/appvolumehotkeys.json";
+}
+
+void KeyboardShortcutManager::loadAppVolumeHotkeys()
+{
+    QFile file(getAppVolumeHotkeysFilePath());
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    file.close();
+
+    if (!doc.isArray())
+        return;
+
+    QJsonArray arr = doc.array();
+    for (const QJsonValue &val : arr) {
+        QJsonObject obj = val.toObject();
+        AppVolumeHotkey hotkey;
+        hotkey.executableName = obj["executableName"].toString();
+        hotkey.volumeUpKey = obj["volumeUpKey"].toInt();
+        hotkey.volumeUpModifiers = obj["volumeUpModifiers"].toInt();
+        hotkey.volumeDownKey = obj["volumeDownKey"].toInt();
+        hotkey.volumeDownModifiers = obj["volumeDownModifiers"].toInt();
+        hotkey.volumeStepSize = obj["volumeStepSize"].toInt(0);
+        m_appVolumeHotkeys.append(hotkey);
+    }
+}
+
+void KeyboardShortcutManager::saveAppVolumeHotkeys()
+{
+    QJsonArray arr;
+    for (const auto &hotkey : m_appVolumeHotkeys) {
+        QJsonObject obj;
+        obj["executableName"] = hotkey.executableName;
+        obj["volumeUpKey"] = hotkey.volumeUpKey;
+        obj["volumeUpModifiers"] = hotkey.volumeUpModifiers;
+        obj["volumeDownKey"] = hotkey.volumeDownKey;
+        obj["volumeDownModifiers"] = hotkey.volumeDownModifiers;
+        obj["volumeStepSize"] = hotkey.volumeStepSize;
+        arr.append(obj);
+    }
+
+    QFile file(getAppVolumeHotkeysFilePath());
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(QJsonDocument(arr).toJson());
+        file.close();
+    }
+}
+
+void KeyboardShortcutManager::registerAppVolumeHotkeys()
+{
+    if (!m_hwnd) return;
+
+    m_nextAppHotkeyId = APP_HOTKEY_BASE_ID;
+
+    for (auto &hotkey : m_appVolumeHotkeys) {
+        // Register volume up
+        UINT upMods = convertQtModifiers(hotkey.volumeUpModifiers);
+        UINT upKey = qtKeyToVirtualKey(hotkey.volumeUpKey);
+        hotkey.volumeUpHotkeyId = m_nextAppHotkeyId++;
+        if (upKey != 0 && RegisterHotKey(m_hwnd, hotkey.volumeUpHotkeyId, upMods, upKey)) {
+            m_registeredHotkeys[hotkey.volumeUpHotkeyId] = true;
+        }
+
+        // Register volume down
+        UINT downMods = convertQtModifiers(hotkey.volumeDownModifiers);
+        UINT downKey = qtKeyToVirtualKey(hotkey.volumeDownKey);
+        hotkey.volumeDownHotkeyId = m_nextAppHotkeyId++;
+        if (downKey != 0 && RegisterHotKey(m_hwnd, hotkey.volumeDownHotkeyId, downMods, downKey)) {
+            m_registeredHotkeys[hotkey.volumeDownHotkeyId] = true;
+        }
+    }
+}
+
+void KeyboardShortcutManager::unregisterAppVolumeHotkeys()
+{
+    if (!m_hwnd) return;
+
+    for (const auto &hotkey : m_appVolumeHotkeys) {
+        if (m_registeredHotkeys.contains(hotkey.volumeUpHotkeyId)) {
+            UnregisterHotKey(m_hwnd, hotkey.volumeUpHotkeyId);
+            m_registeredHotkeys.remove(hotkey.volumeUpHotkeyId);
+        }
+        if (m_registeredHotkeys.contains(hotkey.volumeDownHotkeyId)) {
+            UnregisterHotKey(m_hwnd, hotkey.volumeDownHotkeyId);
+            m_registeredHotkeys.remove(hotkey.volumeDownHotkeyId);
+        }
+    }
+}
+
+bool KeyboardShortcutManager::addAppVolumeHotkey(const QString &executableName, int volUpKey, int volUpMods, int volDownKey, int volDownMods, int volumeStepSize)
+{
+    // Remove existing hotkey for this app if any
+    removeAppVolumeHotkey(executableName);
+
+    AppVolumeHotkey hotkey;
+    hotkey.executableName = executableName;
+    hotkey.volumeUpKey = volUpKey;
+    hotkey.volumeUpModifiers = volUpMods;
+    hotkey.volumeDownKey = volDownKey;
+    hotkey.volumeDownModifiers = volDownMods;
+    hotkey.volumeStepSize = volumeStepSize;
+
+    m_appVolumeHotkeys.append(hotkey);
+    saveAppVolumeHotkeys();
+
+    // Re-register all hotkeys if global shortcuts are enabled
+    if (UserSettings::instance()->globalShortcutsEnabled()) {
+        manageGlobalShortcuts(true);
+    }
+
+    emit appVolumeHotkeysChanged();
+    return true;
+}
+
+void KeyboardShortcutManager::removeAppVolumeHotkey(const QString &executableName)
+{
+    for (int i = 0; i < m_appVolumeHotkeys.size(); ++i) {
+        if (m_appVolumeHotkeys[i].executableName == executableName) {
+            // Unregister these specific hotkeys
+            if (m_hwnd) {
+                if (m_registeredHotkeys.contains(m_appVolumeHotkeys[i].volumeUpHotkeyId)) {
+                    UnregisterHotKey(m_hwnd, m_appVolumeHotkeys[i].volumeUpHotkeyId);
+                    m_registeredHotkeys.remove(m_appVolumeHotkeys[i].volumeUpHotkeyId);
+                }
+                if (m_registeredHotkeys.contains(m_appVolumeHotkeys[i].volumeDownHotkeyId)) {
+                    UnregisterHotKey(m_hwnd, m_appVolumeHotkeys[i].volumeDownHotkeyId);
+                    m_registeredHotkeys.remove(m_appVolumeHotkeys[i].volumeDownHotkeyId);
+                }
+            }
+            m_appVolumeHotkeys.removeAt(i);
+            saveAppVolumeHotkeys();
+            emit appVolumeHotkeysChanged();
+            return;
+        }
+    }
+}
+
+QJsonArray KeyboardShortcutManager::appVolumeHotkeysJson() const
+{
+    QJsonArray arr;
+    for (const auto &hotkey : m_appVolumeHotkeys) {
+        QJsonObject obj;
+        obj["executableName"] = hotkey.executableName;
+        obj["volumeUpKey"] = hotkey.volumeUpKey;
+        obj["volumeUpModifiers"] = hotkey.volumeUpModifiers;
+        obj["volumeDownKey"] = hotkey.volumeDownKey;
+        obj["volumeDownModifiers"] = hotkey.volumeDownModifiers;
+        obj["volumeStepSize"] = hotkey.volumeStepSize;
+        arr.append(obj);
+    }
+    return arr;
 }


### PR DESCRIPTION
## Summary
- Add per-app volume hotkey system with UI in Settings (AppHotkeysPane)
- Extend key mappings to support F13-F24, numbers 0-9, arrow keys, and other common keys
- Add customizable volume step size per hotkey (falls back to global wheel sensitivity)